### PR TITLE
Updates: November 2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ sync-remote-docker-host:
 
 .PHONY: build-dotnet-amazon-linux
 build-dotnet-amazon-linux:
-	cd amazon-linux/dotnet && $(PROGRAM) build -t localhost/dotnet/amazon-linux-2:$(NOW) .
+	cd amazon-linux/dotnet && $(PROGRAM) build -t localhost/dotnet/amazon-linux-2022:$(NOW) .
 
 .PHONY: build-dotnet-opensuse
 build-dotnet-opensuse:
-	cd opensuse/dotnet && $(PROGRAM) build -t localhost/dotnet/opensuse-leap-15.3:$(NOW) .
+	cd opensuse/dotnet && $(PROGRAM) build -t localhost/dotnet/opensuse-leap-15.4:$(NOW) .
 
 .PHONY: build-dotnet-oracle-linux
 build-dotnet-oracle-linux:
-	cd oracle-linux/dotnet && $(PROGRAM) build -t localhost/dotnet/oracle-linux-8.4:$(NOW) .
+	cd oracle-linux/dotnet && $(PROGRAM) build -t localhost/dotnet/oracle-linux-9:$(NOW) .
 
 .PHONY: build-dotnet-photon
 build-dotnet-photon:
@@ -48,19 +48,19 @@ build-dotnet-photon:
 
 .PHONY: build-dotnet-rhel-ubi
 build-dotnet-rhel-ubi:
-	cd rhel-ubi/dotnet && $(PROGRAM) build -t localhost/dotnet/rhel-ubi-8.5:$(NOW) .
+	cd rhel-ubi/dotnet && $(PROGRAM) build -t localhost/dotnet/rhel-ubi-9:$(NOW) .
 
 .PHONY: build-java-amazon-linux
 build-java-amazon-linux:
-	cd amazon-linux/java && $(PROGRAM) build -t localhost/java/amazon-linux-2:$(NOW) .
+	cd amazon-linux/java && $(PROGRAM) build -t localhost/java/amazon-linux-2022:$(NOW) .
 
 .PHONY: build-java-opensuse
 build-java-opensuse:
-	cd opensuse/java && $(PROGRAM) build -t localhost/java/opensuse-leap-15.3:$(NOW) .
+	cd opensuse/java && $(PROGRAM) build -t localhost/java/opensuse-leap-15.4:$(NOW) .
 
 .PHONY: build-java-oracle-linux
 build-java-oracle-linux:
-	cd oracle-linux/java && $(PROGRAM) build -t localhost/java/oracle-linux-8.4:$(NOW) .
+	cd oracle-linux/java && $(PROGRAM) build -t localhost/java/oracle-linux-9:$(NOW) .
 
 .PHONY: build-java-photon
 build-java-photon:
@@ -68,4 +68,4 @@ build-java-photon:
 
 .PHONY: build-java-rhel-ubi
 build-java-rhel-ubi:
-	cd rhel-ubi/java && $(PROGRAM) build -t localhost/java/rhel-ubi-8.5:$(NOW) .
+	cd rhel-ubi/java && $(PROGRAM) build -t localhost/java/rhel-ubi-9:$(NOW) .

--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@
 
 This repo contains Dockerfiles for various combinations.
 
-Most of these are built and tested on Raspberry Pi 3 (aarch64 / arm64 / armv8)
-on top of an openSUSE Leap 15.3 host with Podman.
+aarch64/arm64/armv8 images are built and tested on Raspberry Pi 3 on Oracle
+Linux 9 with Podman.
+
+x86_64 images are built and tested macOS with Podman.
 
 A Makefile is also included to help understand this repo better. You can also
 use it to build images quickly. Supports: vctl, podman, and docker.
 
-| Purpose            | Operating System                         | Notes      |
-|--------------------|------------------------------------------|------------|
-| .NET 6 (Runtime)   | Amazon Linux 2                           | Dockerfile has commented out RUN that supports x86_64. Uncomment it and comment aarch64 RUN as needed. |
-| .NET 6 (Runtime)   | openSUSE Leap 15.3                       | Dockerfile has commented out RUN that supports x86_64. Uncomment it and comment aarch64 RUN as needed. |
-| .NET 6 (Runtime)   | Oracle Linux 8.4                         | Dockerfile uses manual install because .NET 6 is not supported on CentOS 8 and is not available in repos. Dockerfile has commented out RUN that is only supported on x86_64. Uncomment it as needed. |
-| .NET 6 (Runtime)   | Photon 4.0                               | Dockerfile has commented out RUN that supports x86_64. Uncomment it and comment aarch64 RUN as needed. |
-| .NET 6 (Runtime)   | Red Hat Enterprise Linux 8.5 UBI         |  |
-| Java 11 (JRE)      | Amazon Linux 2                           | Uses Amazon Corretto |
-| Java 11 (JRE)      | openSUSE Leap 15.3                       | Uses BellSoft's distribution because of their partnership with VMware |
-| Java 11 (JRE)      | Oracle Linux 8.4                         | Uses OpenJDK |
-| Java 11 (JRE)      | Photon 4.0                               | Uses BellSoft's distribution because of their partnership with VMware. Also uses Oracle Linux 8 repos for some dependencies which are not available in Photon repos. |
-| Java 11 (JRE)      | Red Hat Enterprise Linux 8.5 UBI         |  |
+| Purpose            | Operating System                         | x86_64               | aarch64/arm64        | Notes      |
+|--------------------|------------------------------------------|----------------------|----------------------|------------|
+| .NET 6 (Runtime)   | Amazon Linux 2022                        | Works                | Build failed         | Could not start container on Raspberry Pi 3 (aarch64) |
+| .NET 6 (Runtime)   | openSUSE Leap 15.4                       | Works                | Works                |  |
+| .NET 6 (Runtime)   | Oracle Linux 9                           | Works                | Works                |  |
+| .NET 6 (Runtime)   | Photon 4.0                               | Works w/ workaround  | Works w/ workaround  | Dockerfile has commented out RUN that supports x86_64 but does not work as of 2022-11-01. Consequently, the less-recommended install method is used. |
+| .NET 6 (Runtime)   | Red Hat Enterprise Linux 9 UBI           | Works                | Works                |  |
+| Java 17 (JRE)      | Amazon Linux 2022                        | Works                | Build failed         | Amazon Corretto. Could not start container on Raspberry Pi 3 (aarch64). |
+| Java 17 (JRE)      | openSUSE Leap 15.4                       | Works                | Works                | OpenJDK |
+| Java 17 (JRE)      | Oracle Linux 9                           | Works                | Works                | OpenJDK |
+| Java 17 (JRE)      | Photon 4.0                               | Works                | Works                | Uses BellSoft's distribution because of their partnership with VMware. Also uses Oracle Linux 8 repos for some dependencies which are not available in Photon repos. |
+| Java 17 (JRE)      | Red Hat Enterprise Linux 9 UBI           | Works                | Works                | OpenJDK |

--- a/amazon-linux/dotnet/Dockerfile
+++ b/amazon-linux/dotnet/Dockerfile
@@ -1,18 +1,8 @@
-FROM amazonlinux:2
+FROM amazonlinux:2022
 
-# Since .NET 6 is not supported on CentOS 8, we have to use manual install
-# We are also forced to use manual install on aarch64
-RUN    yum makecache \
-    && yum install -y coreutils gawk gzip krb5-libs libicu libstdc++-devel openssl-libs tar zlib \
-    && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --runtime aspnetcore --install-dir /usr/local/dotnet \
-    && ln -s /usr/local/dotnet/dotnet /usr/local/bin/dotnet
+RUN    dnf makecache \
+    && dnf install -y aspnetcore-runtime-6.0
 
-# Use on x86_64
-# RUN    rpmkeys --import 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' \
-#     && curl -o /etc/yum.repos.d/mono-centos8-stable.repo https://download.mono-project.com/repo/centos8-stable.repo \
-#     && yum makecache \
-#     && yum install -y libgdiplus
+# arm64 / aarch64 not supported as I could not start container on rpi3
 
-# https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
-# https://docs.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual
-# https://docs.microsoft.com/en-us/dotnet/core/install/linux-centos
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-fedora

--- a/amazon-linux/java/Dockerfile
+++ b/amazon-linux/java/Dockerfile
@@ -1,6 +1,8 @@
-FROM amazonlinux:2
+FROM amazonlinux:2022
 
-RUN    yum makecache \
-    && yum install -y java-11-amazon-corretto-headless
+RUN    dnf makecache \
+    && dnf install -y java-17-amazon-corretto-headless
 
-# https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/amazon-linux-install.html
+# arm64 / aarch64 not supported as I could not start container on rpi3
+
+# https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/amazon-linux-install.html

--- a/opensuse/dotnet/Dockerfile
+++ b/opensuse/dotnet/Dockerfile
@@ -1,16 +1,9 @@
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.4
 
-# Use on aarch64
-RUN    zypper refresh \
-    && zypper install -y curl gzip libicu tar \
-    && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --runtime aspnetcore --install-dir /usr/local/dotnet \
-    && ln -s /usr/local/dotnet/dotnet /usr/local/bin/dotnet
-
-# Use on x86_64
-# RUN    rpm --import https://packages.microsoft.com/keys/microsoft.asc \
-#     && curl -o /etc/zypp/repos.d/microsoft-prod.repo https://packages.microsoft.com/config/opensuse/15/prod.repo \
-#     && zypper refresh \
-#     && zypper install -y aspnetcore-runtime-6.0
+RUN    rpm --import https://packages.microsoft.com/keys/microsoft.asc \
+    && curl -o /etc/zypp/repos.d/microsoft-prod.repo https://packages.microsoft.com/config/opensuse/15/prod.repo \
+    && zypper refresh \
+    && zypper install -y aspnetcore-runtime-6.0
 
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-opensuse
 # https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script

--- a/opensuse/java/Dockerfile
+++ b/opensuse/java/Dockerfile
@@ -1,12 +1,4 @@
-FROM opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.4
 
-COPY bellsoft.repo /etc/zypp/repos.d/
-
-RUN    zypper --gpg-auto-import-keys refresh --repo BellSoft \
-    && zypper refresh \
-    && zypper install -y bellsoft-java11-runtime-full \
-    && update-alternatives --set java "/usr/lib/jvm/bellsoft-java11-runtime-full.$(uname -m)/bin/java"
-
-# https://bell-sw.com/pages/downloads/#/java-11-lts
-
-# Also installs jaotc but not javac
+RUN    zypper refresh \
+    && zypper install -y java-17-openjdk-headless

--- a/opensuse/java/bellsoft.repo
+++ b/opensuse/java/bellsoft.repo
@@ -1,8 +1,0 @@
-[BellSoft]
-name=BellSoft Repository
-baseurl=https://yum.bell-sw.com
-enabled=1
-gpgcheck=1
-gpgkey=https://download.bell-sw.com/pki/GPG-KEY-bellsoft
-priority=1
-skip_if_unavailable=True

--- a/oracle-linux/dotnet/Dockerfile
+++ b/oracle-linux/dotnet/Dockerfile
@@ -1,18 +1,6 @@
-FROM oraclelinux:8.4
+FROM container-registry.oracle.com/os/oraclelinux:9
 
-# Since .NET 6 is not supported on CentOS 8, we have to use manual install
-# We are also forced to use manual install on aarch64
 RUN    dnf makecache \
-    && dnf install -y coreutils gawk krb5-libs libicu libstdc++-devel openssl-libs tar zlib \
-    && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --runtime aspnetcore --install-dir /usr/local/dotnet \
-    && ln -s /usr/local/dotnet/dotnet /usr/local/bin/dotnet
+    && dnf install -y aspnetcore-runtime-6.0
 
-# Use on x86_64
-# RUN    rpmkeys --import 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' \
-#     && curl -o /etc/yum.repos.d/mono-centos8-stable.repo https://download.mono-project.com/repo/centos8-stable.repo \
-#     && dnf makecache \
-#     && dnf install -y libgdiplus
-
-# https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
-# https://docs.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual
-# https://docs.microsoft.com/en-us/dotnet/core/install/linux-centos
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-fedora

--- a/oracle-linux/java/Dockerfile
+++ b/oracle-linux/java/Dockerfile
@@ -1,8 +1,6 @@
-FROM oraclelinux:8.4
+FROM container-registry.oracle.com/os/oraclelinux:9
 
 RUN    dnf makecache \
-    && dnf install -y java-11-openjdk
+    && dnf install -y java-17-openjdk
 
-# https://access.redhat.com/documentation/en-us/openjdk/11/pdf/using_alt-java/openjdk-11-using_alt-java-en-us.pdf
-
-# To install javac and jaotc install package java-11-openjdk-devel
+# To install javac and jaotc install package java-17-openjdk-devel

--- a/photon/dotnet/Dockerfile
+++ b/photon/dotnet/Dockerfile
@@ -1,12 +1,13 @@
-FROM photon:4.0
+FROM docker.io/library/photon:4.0
 
-# Use on aarch64
+# Use on aarch64 and x86_64
 RUN    tdnf makecache \
     && tdnf install -y coreutils gawk icu-devel libstdc++-devel \
     && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --runtime aspnetcore --install-dir /usr/local/dotnet \
     && ln -s /usr/local/dotnet/dotnet /usr/local/bin/dotnet
 
 # Use on x86_64
+# DOES NOT WORK AS OF 2022-11-01
 # RUN    rpm --import https://packages.microsoft.com/keys/microsoft.asc \
 #     && curl -o /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/opensuse/15/prod.repo \
 #     && tdnf makecache \

--- a/photon/java/Dockerfile
+++ b/photon/java/Dockerfile
@@ -1,11 +1,11 @@
-FROM photon:4.0
+FROM docker.io/library/photon:4.0
 
 COPY bellsoft.repo /etc/yum.repos.d/
 COPY oracle-linux-8.repo /etc/yum.repos.d/
 
 RUN    tdnf --enablerepo=ol8 --enablerepo=BellSoft makecache \
-    && tdnf install --enablerepo=ol8 --enablerepo=BellSoft -y bellsoft-java11-runtime-full
+    && tdnf install --enablerepo=ol8 --enablerepo=BellSoft -y bellsoft-java17-runtime-full
 
-# https://bell-sw.com/pages/downloads/#/java-11-lts
+# https://bell-sw.com/pages/downloads/#/java-17-lts
 
 # Also installs jaotc but not javac

--- a/rhel-ubi/dotnet/Dockerfile
+++ b/rhel-ubi/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8:8.5
+FROM registry.access.redhat.com/ubi9/ubi
 
 RUN    dnf makecache \
     && dnf install -y dotnet-runtime-6.0 \

--- a/rhel-ubi/java/Dockerfile
+++ b/rhel-ubi/java/Dockerfile
@@ -1,8 +1,8 @@
-FROM redhat/ubi8:8.5
+FROM registry.access.redhat.com/ubi9/ubi
 
 RUN    dnf makecache \
-    && dnf install -y java-11-openjdk
+    && dnf install -y java-17-openjdk
 
-# https://access.redhat.com/documentation/en-us/openjdk/11/pdf/using_alt-java/openjdk-11-using_alt-java-en-us.pdf
+# https://access.redhat.com/documentation/en-us/openjdk/17/pdf/using_alt-java/openjdk-17-using_alt-java-en-us.pdf
 
-# To install javac and jaotc install package java-11-openjdk-devel
+# To install javac and jaotc install package java-17-openjdk-devel


### PR DESCRIPTION
- Upgrade OS versions
- Upgrade to Java 17
- Migrate to OpenJDK from BellSoft in some OSes